### PR TITLE
fix resolve_variables_cb

### DIFF
--- a/src/build_opts.c
+++ b/src/build_opts.c
@@ -154,7 +154,7 @@ static int resolve_variables_cb(void *ctx, void *data) {
 
             size_t max_loops = 10;
             for (size_t j = 0;; ++j) {
-                ccstrview var = find_variable(ccsv(optval));
+                ccstr var = find_variable(ccsv(optval));
                 if (var.len == 0) {
                     break;
                 }
@@ -162,9 +162,11 @@ static int resolve_variables_cb(void *ctx, void *data) {
                     printf("config error: failed to resolve variable '%.*s'\n", var.len, var.cstr);
                     exit(1);
                 }
-                ccstrview varname = ccsv_slice(var, 2, var.len - 3);
+                ccstrview varname = ccsv_slice(ccsv(&var), 2, var.len - 3);
                 ccstrview value = get_var_value(build_option_defs, opts, varname);
-                ccstr_replace(optval, var, value);
+
+                ccstr_replace(optval, ccsv(&var), value);
+                ccstr_free(&var);
             }
         }
     }

--- a/src/build_opts_helpers.h
+++ b/src/build_opts_helpers.h
@@ -67,26 +67,21 @@ static char* find_compiler(const char *compiler_list) {
     exit(1);
 }
 
-// Detects a variable in the format $(VARNAME) and returns it as a ccstrview
-// Returns a zero-length ccstrview if no variable is found
-static ccstrview find_variable(ccstrview sv) {
-    ccstrview result = {0};
-
+// Detects a variable in the format $(VARNAME) and returns a copy of it
+// Returns a zero-length ccstr if no variable is found
+static ccstr find_variable(ccstrview sv) {
     if (!sv.cstr || sv.len == 0) {
-        return result;
+        return ccstr_empty(0);
     }
     int start = ccstrstr(sv, CCSTRVIEW_STATIC("$("));
     if (start == -1) {
-        return result;
+        return ccstr_empty(0);
     }
     int end = ccstrstr(ccsv_offset(sv, start), CCSTRVIEW_STATIC(")"));
     if (end == -1) {
-        return result;
+        return ccstr_empty(0);
     }
-    return (ccstrview) {
-        .cstr = sv.cstr + start,
-        .len = end + 1,
-    };
+    return ccstr_rawlen(sv.cstr + start, end + 1);
 }
 
 // the build order of targets can be specified by adding


### PR DESCRIPTION
the var extracted from optval cannot be a view into optval.  A copy is needed in case optval is realloc'd while performing the ccstr_replace